### PR TITLE
Separated getting task to be used with different events

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -178,7 +178,22 @@ function makeSwimlanes(list) {
   return swimlanes;
 }
 
-Actions.getTasksForProject = (workspaceId, projectId) => {
+const getTasksForProject = (dispatch, workspaceId, projectId) => {
+  const project = Project(projectId);
+  project.getTasks(AsanaClient)
+  .then((tasks) => {
+    dispatch({
+      type: 'RECEIVED_SECTIONS_AND_TASKS',
+      payload: {
+        workspaceId: workspaceId,
+        projectId: projectId,
+        sections: makeSwimlanes(tasks)
+      }
+    })
+  });
+};
+
+Actions.getInitialTasksForProject = (workspaceId, projectId) => {
   return (dispatch) => {
     // First dispatch the selection incase we can get the sections from the tree already
     dispatch({
@@ -189,21 +204,16 @@ Actions.getTasksForProject = (workspaceId, projectId) => {
       }
     });
 
-    const project = Project(projectId);
-
-    project.getTasks(AsanaClient)
-    .then((tasks) => {
-      dispatch({
-        type: 'RECEIVED_SECTIONS_AND_TASKS',
-        payload: {
-          workspaceId: workspaceId,
-          projectId: projectId,
-          sections: makeSwimlanes(tasks)
-        }
-      })
-    });
+    getTasksForProject(dispatch, workspaceId, projectId);
   };
 };
+
+Actions.updateTasksForProject = (workspaceId, projectId) => {
+  return (dispatch) => {
+    dispatch({ type: 'UPDATE_SECTIONS_AND_TASKS' });
+    getTasksForProject(dispatch, workspaceId, projectId);
+  };
+}
 
 Actions.checkAuth = () => {
   return (dispatch) => {

--- a/app/containers/SidebarContainer.js
+++ b/app/containers/SidebarContainer.js
@@ -13,7 +13,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     onProjectSelected: (workspaceId, projectId) => {
-      dispatch(Actions.getTasksForProject(workspaceId, projectId));
+      dispatch(Actions.getInitialTasksForProject(workspaceId, projectId));
       dispatch(UIActions.hideSidebar());
     }
   };

--- a/app/store/AsanaEventPoller.js
+++ b/app/store/AsanaEventPoller.js
@@ -36,7 +36,7 @@ const AsanaEventPoller = (store) => {
               type: 'RECEIVE_EVENT'
             });
 
-            store.dispatch(Actions.getTasksForProject(_workspaceId, _projectId));
+            store.dispatch(Actions.updateTasksForProject(_workspaceId, _projectId));
           }
         }
 


### PR DESCRIPTION
Moved getting tasks action into two functions so that it can be used for initial fetching and then updating.
Resolves #79.
