### PR TITLE
Added proxima font back to the correct place

### DIFF
--- a/app/scss/common.scss
+++ b/app/scss/common.scss
@@ -11,9 +11,17 @@ p {
   margin: 0;
 }
 
+html,
+button,
+input,
+select,
+textarea,
+.pure-g [class *= "pure-u"] {
+  font-family: "proxima-nova",sans-serif;
+}
+
 body {
   background-color: #FFFFFF;
-  font-family: "proxima-nova",sans-serif;
 }
 
 .pull-right {


### PR DESCRIPTION
This was moved from the `*` to the `body` however the docs inform to put it on a range of elements.
http://purecss.io/grids/#using-grids-with-custom-fonts
