### PR TITLE
Readded fallback of getting all cards

### DIFF
--- a/app/reducers/entities/sections.js
+++ b/app/reducers/entities/sections.js
@@ -2,7 +2,9 @@ import { combineReducers } from 'redux'
 import update from 'react/lib/update';
 
 const getCardIndex = (state, cardId, sectionId) => {
-  return state[sectionId].cards.indexOf(cardId);
+  let index = state[sectionId].cards.indexOf(cardId);
+  index = index == -1 ? 0 : index;
+  return index;
 };
 
 const addCard = (state, cardId, sectionId) => {
@@ -71,7 +73,7 @@ const records = (state = {}, action) => {
       const removedCardState = removeCard(state, cardToMove.id, cardToMove.sectionId);
 
       // Find the index of the card to insert after
-      const index = getCardIndex(removedCardState, cardToInsertAfter.id, cardToInsertAfter.sectionId);
+      let index = getCardIndex(removedCardState, cardToInsertAfter.id, cardToInsertAfter.sectionId);
 
       // Insert the card in the new position
       return insertCard(removedCardState, cardToMove.id, cardToInsertAfter.sectionId, index + 1);

--- a/app/store/AsanaEventPoller.js
+++ b/app/store/AsanaEventPoller.js
@@ -32,7 +32,11 @@ const AsanaEventPoller = (store) => {
 
             store.dispatch({ type: 'RECEIVE_EVENT' });
 
-            store.dispatch(Actions.getTask(event.data[0].resource.id));
+            if (event.data[0].resource.id === _projectId) {
+              store.dispatch(Actions.updateTasksForProject(event.data[0].resource.id));
+            } else {
+              store.dispatch(Actions.getTask(event.data[0].resource.id), _projectId);
+            }
           }
         }
 


### PR DESCRIPTION
When a card is moved Asana only give us the project id that the card id has been moved within. Therefore I've readded in the reloading of a project in the case of only being given the project id.
