### PR TITLE
Inverted location of task detail colours

### DIFF
--- a/app/components/TaskDetailsSidebar/style.scss
+++ b/app/components/TaskDetailsSidebar/style.scss
@@ -15,9 +15,9 @@ $sidebar-components-vertical-padding: 25px;
   width: $task-sidebar-width;
   height: 100%;
   border-left: 1px solid $sidebar-border-colour;
-  padding-top: $header-height + $sidebar-vertical-padding;
+  padding-top: $header-height;
   padding-bottom: 0;
-  background-color: $sidebar-secondary-colour;
+  background-color: $sidebar-primary-colour;
   overflow-y: scroll;
 
   &.active {
@@ -26,11 +26,17 @@ $sidebar-components-vertical-padding: 25px;
 
   &.loading {
     background-color: $sidebar-primary-colour;
+
+    .task-details-sidebar__close {
+      background-color: $sidebar-primary-colour;
+    }
   }
 
   &__close {
+    padding-top: $sidebar-vertical-padding;
     padding-right: $sidebar-horizontal-padding;
     padding-left: $sidebar-horizontal-padding;
+    background-color: $sidebar-secondary-colour;
     text-align: right;
 
     &__icon {
@@ -44,6 +50,7 @@ $sidebar-components-vertical-padding: 25px;
     padding-right: $sidebar-horizontal-padding;
     padding-left: $sidebar-horizontal-padding;
     border-bottom: 1px solid $sidebar-border-colour;
+    background-color: $sidebar-secondary-colour;
   }
 
   &__comment-list {


### PR DESCRIPTION
Instead of giving a white background to the comments and a grey background to the sidebar, this has been swapped. This means that when there are only a few comment the white background still fills the section.
