### PR TITLE
Ensured section name changes retained a colon

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -510,6 +510,12 @@ Actions.updateSection = (params) => {
         .then(() => { dispatch({ type: 'DELETING_CARD_SUCCESS' }); })
         .catch(() => { dispatch({ type: 'DELETING_CARD_FAILED' }); });
       } else {
+        // Ensure there is a semi colon at the end
+        if (details.name.slice(-1) !== ':') {
+          details.name += ':';
+        }
+
+        updateSection(dispatch, details);
         task.update(details)
         .then(() => { dispatch({ type: 'UPDATING_CARD_SUCCESS' }); })
         .catch(() => { dispatch({ type: 'UPDATING_CARD_FAILED' }); });

--- a/app/containers/AddASectionSwimlaneContainer.js
+++ b/app/containers/AddASectionSwimlaneContainer.js
@@ -37,13 +37,19 @@ const mapDispatchToProps = (dispatch) => {
       }
     },
     onSectionUpdated: (section, currentProjectId, firstSectionId, updateAsana) => {
-      const options = {
-        details: section,
-        projectId: currentProjectId,
-        firstSectionId: firstSectionId
-      };
-
       if (updateAsana && section.name.trim() !== '') {
+        section.name = section.name.trim();
+        const options = {
+          details: section,
+          projectId: currentProjectId,
+          firstSectionId: firstSectionId
+        };
+
+        // Ensure there is a colon at the end
+        if (section.name.slice(-1) !== ':') {
+          options.details.name += ':';
+        }
+
         dispatch(Actions.createSection(options));
       }
     },


### PR DESCRIPTION
Colon was required to keep the section a section rather than converting it to a task.
