### PR TITLE
Firefox could not scroll

### DIFF
--- a/app/components/Swimlane/style.scss
+++ b/app/components/Swimlane/style.scss
@@ -81,7 +81,6 @@ $swimlane-height-small: 250px;
     // Hide scoll bars
     // blogs.msdn.microsoft.com/kurlak/2013/11/03/hiding-vertical-scrollbars-with-pure-css-in-chrome-ie-6-firefox-opera-and-safari/
     -ms-overflow-style: none;
-    overflow: -moz-scrollbars-none;
     &::-webkit-scrollbar { width: 0 !important }
 
     &--full-height {
@@ -126,7 +125,6 @@ $swimlane-height-small: 250px;
   // Hide scoll bars
   // blogs.msdn.microsoft.com/kurlak/2013/11/03/hiding-vertical-scrollbars-with-pure-css-in-chrome-ie-6-firefox-opera-and-safari/
   -ms-overflow-style: none;
-  overflow: -moz-scrollbars-none;
   &::-webkit-scrollbar { width: 0 !important }
 
 }


### PR DESCRIPTION
The hack to hide scrollbars actually results in scroll not working at all in firefox. Remove css.